### PR TITLE
reset timed transitions when changing state

### DIFF
--- a/src/SimpleFSM.cpp
+++ b/src/SimpleFSM.cpp
@@ -344,6 +344,10 @@ bool SimpleFSM::_changeToState(State* s, unsigned long now) {
   // save the time
   last_run = now;
   last_transition = now;
+  // reset timed transitions
+  for (int i = 0; i < num_timed; i++) {
+    timed[i].reset();
+  }
   // is this the end?
   if (s->is_final && finished_cb != NULL) finished_cb();
   if (s->is_final) is_finished = true;


### PR DESCRIPTION
Timed transitions start counting when a new state is entered. After they reach their set time, they trigger a state change and reset. But if a state change is triggered not by the timed transition itself, the timed transition is never reset. This is fixed here.